### PR TITLE
correct y axis and set custom bounding box

### DIFF
--- a/src/modules/octopi/filesystem/home/pi/.octoprint/printerProfiles/_default.profile
+++ b/src/modules/octopi/filesystem/home/pi/.octoprint/printerProfiles/_default.profile
@@ -6,7 +6,7 @@ axes:
     inverted: false
     speed: 10200
   y:
-    inverted: false
+    inverted: true
     speed: 10200
   z:
     inverted: false
@@ -24,7 +24,13 @@ id: _default
 name: Prusa i3 MK3
 model: Prusa i3 MK3
 volume:
-  custom_box: false
+  custom_box:
+    x_max: 250.0
+    x_min: 0.0
+    y_max: 210.0
+    y_min: -4.0
+    z_max: 210.0
+    z_min: 0.0
   formFactor: rectangular
   origin: lowerleft
   width: 250.0


### PR DESCRIPTION
the y axis is inverted and needs to be set to true. currently when you control the bed, if you press the up arrow on the control tab it will move the bed towards you. this isnt intuitive as you'd expect the bed to be moved away from you as normally you are looking at the bed from the LCD side (front) in the webcam.

also the y axis is allowed to technically move to -4, setting a custom bound box prevents errors for plugins such as octolapse who expect the printer to be within the bed WxHxD or custom bound box.